### PR TITLE
Refactor expressions to store variables.

### DIFF
--- a/notebooks/experimental/mzmbraiding.ipynb
+++ b/notebooks/experimental/mzmbraiding.ipynb
@@ -35,10 +35,10 @@
     "\n",
     "from simuq.solver import generate_as\n",
     "from simuq.systems.mzmbraiding import qs\n",
-    "from simuq.aais.ibm_braiding import IbmBraidingFactory\n",
+    "from simuq.aais import ibm_braiding\n",
     "from simuq.backends.qiskit_braiding import transpile\n",
     "#from simuq.systems.annealing import qs\n",
-    "#from simuq.aais.ibm import get_mach\n",
+    "#from simuq.aais import ibm\n",
     "#mach = get_mach(backend)\n",
     "#from simuq.backends.qiskit_pulse_ibm import transpile"
    ]
@@ -106,7 +106,7 @@
     "Trot = 1\n",
     "tol = 0.1\n",
     "\n",
-    "mach = IbmBraidingFactory().generate_qmachine(n=3)\n",
+    "mach = ibm_braiding.generate_qmachine(n=3)\n",
     "# type(mach)\n",
     "circ = transpile(backend, *generate_as(new_qs, mach, Trot, 'least_squares', tol))"
    ]

--- a/simuq/expression.py
+++ b/simuq/expression.py
@@ -20,17 +20,23 @@ import numpy as np
 class BaseVar :
     """ The basic variables.
 
-    The constrainsts specific to the variables are stored here,
+    The constraints specific to the variables are stored here,
     like the initial value, lower and upper bounds of them.
     """
-    def __init__(self, mach) :
-        self.mach = mach
-        self.init_value = 0
-        self.lower_bound = -np.inf
-        self.upper_bound = np.inf
+    def __init__(self, init_value = 0, lower_bound = -np.inf, upper_bound = np.inf) :
+        self.init_value = init_value
+        self.lower_bound = lower_bound
+        self.upper_bound = upper_bound
+        self.index = None
 
     def to_exp(self) :
-        pass
+        return Expression.id_var(self)
+
+    # Index should allow the value of the BaseVar to be obtained from a list of values of global and local variables.
+    # Global variables have indices from 0 to num_gvars - 1
+    # Local variables have indices from num_gvars to num_gvars + num_lvars - 1
+    def set_index(self, index):
+        self.index = index
 
     def __neg__(self) :
         return -self.to_exp()
@@ -47,30 +53,33 @@ class BaseVar :
     def __truediv__(self, other) :
         return self.to_exp() / other
 
+# Given two lists, return the union, and the indices of the items of the original lists in the union.
+def find_union_indices(list1, list2):
+    union_list = list(set(list1).union(list2))
+    union_dict = dict((item, index) for index, item in enumerate(union_list))
+    indices1 = [union_dict[item] for item in list1]
+    indices2 = [union_dict[item] for item in list2]
+    return union_list, indices1, indices2
+
 class Expression :
     """ The expressions.
     
     It is effectively a function taking a valuation of global variables
     and local variables and generating a number.
     """
-    def __init__(self, mach, exp) :
-        self.mach = mach
+    def __init__(self, exp, vars) :
         self.exp = exp
+        self.vars = vars
 
     @classmethod
-    def unit(cls, mach) :
-        exp = lambda gvars, lvars : 1
-        return cls(mach, exp)
-    
-    @classmethod
-    def id_gvar(cls, mach, index) :
-        exp = lambda gvars, lvars : gvars[index]
-        return cls(mach, exp)
+    def unit(cls) :
+        exp = lambda values: 1
+        return cls(exp, [])
 
     @classmethod
-    def id_lvar(cls, mach, index) :
-        exp = lambda gvars, lvars : lvars[index]
-        return cls(mach, exp)
+    def id_var(cls, var) :
+        exp = lambda values: values[0]
+        return cls(exp, [var])
 
     @classmethod
     def cos(cls, e) :
@@ -81,8 +90,8 @@ class Expression :
         if isinstance(e, np.float64) :
             return np.cos(e)
 
-        def exp(gvars, lvars) :
-            sub = e.exp(gvars, lvars)
+        def exp(values) :
+            sub = e.exp(values)
             if type(sub) == int  or  type(sub) == float :
                 return math.cos(sub)
             if isinstance(sub, np.float64) :
@@ -90,10 +99,9 @@ class Expression :
             import dreal as dr
             if isinstance(sub, dr._dreal_py.Variable)  or  isinstance(sub, dr._dreal_py.Expression) :
                 return dr.cos(sub)
-            pp = qq
             return NotImplemented
 
-        return cls(e.mach, exp)
+        return cls(exp, e.vars)
 
     @classmethod
     def sin(cls, e) :
@@ -104,36 +112,38 @@ class Expression :
         if isinstance(e, np.float64) :
             return np.sin(e)
         
-        def exp(gvars, lvars) :
-            sub = e.exp(gvars, lvars)
+        def exp(values) :
+            sub = e.exp(values)
             if type(sub) == int  or  type(sub) == float :
                 return math.sin(sub)
             if isinstance(sub, np.float64) :
                 return np.sin(sub)
             import dreal as dr
-            if type(sub) == dr._dreal_py.Variable  or  type(sub) == d._dreal_py.Expression :
+            if type(sub) == dr._dreal_py.Variable  or  type(sub) == dr._dreal_py.Expression :
                 return dr.sin(sub)
-            pp = qq
             return NotImplemented
         
-        return cls(e.mach, exp)
+        return cls(exp, e.vars)
 
     def __neg__(self) :
-        exp = lambda gvars, lvars : -self.exp(gvars, lvars)
-        e = Expression(self.mach, exp)
+        exp = lambda vars : -self.exp(vars)
+        e = Expression(exp, self.vars)
         return e
 
     def __add__(self, other) :
         if type(other) == int  or  type(other) == float  or  type(other) == complex :
-            exp = lambda gvars, lvars : self.exp(gvars, lvars) + other
-            e = Expression(self.mach, exp)
+            exp = lambda values : self.exp(values) + other
+            e = Expression(exp, self.vars)
             return e
         if isinstance(other, BaseVar) :
             other = other.to_exp()
         if not hasattr(other, "exp") :
             return NotImplemented
-        exp = lambda gvars, lvars : self.exp(gvars, lvars) + other.exp(gvars, lvars)
-        e = Expression(self.mach, exp)
+
+        new_vars, indices1, indices2 = find_union_indices(self.vars, other.vars)
+        exp = lambda values: self.exp([values[index] for index in indices1]) + other.exp(
+            [values[index] for index in indices2])
+        e = Expression(exp, new_vars)
         return e
 
     def __sub__(self, other) :
@@ -150,15 +160,18 @@ class Expression :
 
     def __mul__(self, other) :
         if type(other) == int  or  type(other) == float  or  type(other) == complex :
-            exp = lambda gvars, lvars : self.exp(gvars, lvars) * other
-            e = Expression(self.mach, exp)
+            exp = lambda values : self.exp(values) * other
+            e = Expression(exp, self.vars)
             return e
         if isinstance(other, BaseVar) :
             other = other.to_exp()
         if not hasattr(other, "exp") :
             return NotImplemented
-        exp = lambda gvars, lvars : self.exp(gvars, lvars) * other.exp(gvars, lvars)
-        e = Expression(self.mach, exp)
+
+        new_vars, indices1, indices2 = find_union_indices(self.vars, other.vars)
+        exp = lambda values: self.exp([values[index] for index in indices1]) * other.exp(
+            [values[index] for index in indices2])
+        e = Expression(exp, new_vars)
         return e
 
     def __rmul__(self, other) :
@@ -172,42 +185,54 @@ class Expression :
 
     def __pow__(self, other) :
         if type(other) == int  or  type(other) == float  or  type(other) == complex :
-            exp = lambda gvars, lvars : self.exp(gvars, lvars) ** other
-            e = Expression(self.mach, exp)
+            exp = lambda values : self.exp(values) ** other
+            e = Expression(exp, self.vars)
             return e
         if isinstance(other, BaseVar) :
             other = other.to_exp()
         if not hasattr(other, "exp") :
             return NotImplemented
-        exp = lambda gvars, lvars : self.exp(gvars, lvars) ** other.exp(gvars, lvars)
-        e = Expression(self.mach, exp)
+
+        new_vars, indices1, indices2 = find_union_indices(self.vars, other.vars)
+        exp = lambda values: self.exp([values[index] for index in indices1]) ** other.exp(
+            [values[index] for index in indices2])
+        e = Expression(exp, new_vars)
         return e
 
     def __truediv__(self, other) :
         if type(other) == int  or  type(other) == float  or  type(other) == complex :
-            exp = lambda gvars, lvars : self.exp(gvars, lvars) / other
-            e = Expression(self.mach, exp)
+            exp = lambda values : self.exp(values) / other
+            e = Expression(exp, self.vars)
             return e
         if isinstance(other, BaseVar) :
             other = other.to_exp()
         if not hasattr(other, "exp") :
             return NotImplemented
-        exp = lambda gvars, lvars : self.exp(gvars, lvars) / other.exp(gvars, lvars)
-        e = Expression(self.mach, exp)
+        new_vars, indices1, indices2 = find_union_indices(self.vars, other.vars)
+        exp = lambda values: self.exp([values[index] for index in indices1]) / other.exp(
+            [values[index] for index in indices2])
+        e = Expression(exp, new_vars)
         return e
 
     def __rtruediv__(self, other) :
         if type(other) == int  or  type(other) == float  or  type(other) == complex :
-            exp = lambda gvars, lvars : other / self.exp(gvars, lvars)
-            e = Expression(self.mach, exp)
+            exp = lambda values : other / self.exp(values)
+            e = Expression(exp, self.vars)
             return e
         if isinstance(other, BaseVar) :
             other = other.to_exp()
         if not hasattr(other, "exp") :
             return NotImplemented
-        exp = lambda gvars, lvars : other.exp(gvars, lvars) / self.exp(gvars, lvars)
-        e = Expression(self.mach, exp)
+
+        new_vars, indices1, indices2 = find_union_indices(other.vars, self.vars)
+        exp = lambda values: other.exp([values[index] for index in indices1]) / self.exp(
+            [values[index] for index in indices2])
+        e = Expression(exp, new_vars)
+
         return e
 
     def exp_eval(self, gvars, lvars) :
-        return self.exp(gvars, lvars)
+        # The weird comprehension below is to handle np array shapes
+        values = [gvar for gvar in gvars] + [lvar for lvar in lvars]
+        return_val = self.exp([values[var.index] for var in self.vars])
+        return return_val

--- a/simuq/expression.py
+++ b/simuq/expression.py
@@ -23,7 +23,7 @@ class BaseVar :
     The constraints specific to the variables are stored here,
     like the initial value, lower and upper bounds of them.
     """
-    def __init__(self, init_value = 0, lower_bound = -np.inf, upper_bound = np.inf) :
+    def __init__(self, init_value=0, lower_bound=-np.inf, upper_bound=np.inf):
         self.init_value = init_value
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound

--- a/simuq/solver.py
+++ b/simuq/solver.py
@@ -759,7 +759,7 @@ def generate_as(qs, mach, trotter_num=4, solver='least_squares', solver_tol = No
     if solver_tol != None :
         solver_args['tol'] = solver_tol
     ali = [] if override_layout == None else override_layout
-    mach.instantiate_sys_ham()
+    mach.instantiate()
     mach.extend_instruction_sites()
     if find_sol(qs, mach, ali = ali, solver=solver, solver_args=solver_args, verbose = verbose):
         sol = gsol


### PR DESCRIPTION
Expressions now store BaseVars. At evaluation time, the indices of the variables will be used to index into the provided arrays of values.

SignalLine no longer holds a reference to its QMachine.
Instruction no longer holds references to its SignalLine or its QMachine.

The distinction between GlobalVar and LocalVar are removed.