### PR TITLE
Add an optimizer for the IonQ native gateset

### DIFF
--- a/simuq/backends/ionq.py
+++ b/simuq/backends/ionq.py
@@ -1,65 +1,6 @@
-# Currently this file is not usable:
-# AWS Braket does not support arbitrary-angle MS gate for now
-# Will be tested later
-# If you want to use IonQ's device through braket,
-# try qiskit_iontrap.py which generates a circuit in bk_c.
-
 import networkx as nx
 import numpy as np
-
-
-class Circuit:
-    def __init__(self, name, n_qubits, backend="simulator", noise_model=None):
-        self.job = {
-            "lang": "json",
-            "shots": 4096,
-            "name": name,
-            "target": "simulator",
-            "body": {
-                "gateset": "native",
-                "qubits": n_qubits,
-                "circuit": [],
-            },
-        }
-        self.job["target"] = backend
-        if noise_model is not None:
-            self.job["noise"] = {"model": noise_model}
-
-    def gpi2(self, q, phi):
-        self.job["body"]["circuit"].append({})
-        gate = self.job["body"]["circuit"][-1]
-        gate["gate"] = "gpi2"
-        gate["target"] = q
-        gate["phase"] = (phi / (2 * np.pi)) % 1
-
-    def gpi(self, q, phi):
-        self.job["body"]["circuit"].append({})
-        gate = self.job["body"]["circuit"][-1]
-        gate["gate"] = "gpi"
-        gate["target"] = q
-        gate["phase"] = (phi / (2 * np.pi)) % 1
-
-    def ms(self, q0, q1, phi0, phi1, theta):
-        # assume angle is between 0 and 1
-        if 0 <= theta <= np.pi / 2:
-            self.job["body"]["circuit"].append({})
-            gate = self.job["body"]["circuit"][-1]
-            gate["gate"] = "ms"
-            gate["targets"] = [q0, q1]
-            gate["phases"] = [(phi0 / (2 * np.pi)) % 1, (phi1 / (2 * np.pi)) % 1]
-            gate["angle"] = theta / (2 * np.pi)
-        elif 3 * np.pi / 2 <= theta <= 2 * np.pi:
-            self.job["body"]["circuit"].append({})
-            gate = self.job["body"]["circuit"][-1]
-            gate["gate"] = "ms"
-            gate["targets"] = [q0, q1]
-            gate["phases"] = [(phi0 / (2 * np.pi)) % 1, ((phi1 + np.pi) / (2 * np.pi)) % 1]
-            gate["angle"] = 1 - theta / (2 * np.pi)
-        else:
-            raise ValueError(
-                f"Parameter theta is {theta}, must be between 0 and pi/2 or 3*pi/2 and 2*pi (use two gates instead)"
-            )
-
+from ionq_circuit import Circuit
 
 def clean_as(n, boxes, edges, backend="simulator", noise_model=None):
     link = [(i, j) for i in range(n) for j in range(i + 1, n)]
@@ -68,8 +9,7 @@ def clean_as(n, boxes, edges, backend="simulator", noise_model=None):
     DG.add_edges_from(edges)
     topo_order = list(nx.topological_sort(DG))
     circ = Circuit("test", n, backend, noise_model)
-    accum_phase = [0 for i in range(n)]
-
+    
     for i in range(len(boxes)):
         idx = topo_order[i]
         t = boxes[idx][1]
@@ -81,147 +21,55 @@ def clean_as(n, boxes, edges, backend="simulator", noise_model=None):
                     rot = 2 * params[0] * t
                     phi = params[1]
                     if abs(rot) > 1e-5:
-                        # Rz(q, phi)
-                        accum_phase[q] -= phi
-                        accum_phase[q] %= 2 * np.pi
+                        circ.rz(q, phi)
+                        
                         # Rx(q, rot)
-                        if abs(rot / (2 * np.pi) - 0.25) < 1e-6:
-                            circ.gpi2(q, (accum_phase[q] + 0) % (2 * np.pi))
-                        elif abs(rot / (2 * np.pi) + 0.25) < 1e-6:
-                            circ.gpi2(q, (accum_phase[q] + np.pi) % (2 * np.pi))
-                        elif abs(rot / (2 * np.pi) - 0.5) < 1e-6:
-                            circ.gpi(q, (accum_phase[q] + 0) % (2 * np.pi))
-                        elif abs(rot / (2 * np.pi) + 0.5) < 1e-6:
-                            circ.gpi(q, (accum_phase[q] + np.pi) % (2 * np.pi))
+                        turns = rot / (2 * np.pi)
+                        if abs(turns - 0.25) < 1e-6:
+                            circ.gpi2(q, 0)
+                        elif abs(turns - 0.75) < 1e-6:
+                            circ.gpi2(q, np.pi)
+                        elif abs(turns - 0.5) < 1e-6:
+                            circ.gpi(q, 0)
                         else:
-                            circ.gpi2(q, (accum_phase[q] + 3 * np.pi / 2) % (2 * np.pi))
-                            accum_phase[q] -= rot
-                            accum_phase[q] %= 2 * np.pi
-                            circ.gpi2(q, (accum_phase[q] + np.pi / 2) % (2 * np.pi))
-                        # Rz(q, -phi)
-                        accum_phase[q] += phi
-                        accum_phase[q] %= 2 * np.pi
+                            circ.gpi2(q, 3 * np.pi / 2)
+                            circ.rz(q, rot)
+                            circ.gpi2(q, np.pi / 2)
+                        
+                        circ.rz(q, -phi)
 
                 else:
                     q = line
-                    # Rz(q, 2 * params[0] * t)
-                    accum_phase[q] -= 2 * params[0] * t
-                    accum_phase[q] %= 2 * np.pi
+                    # expm(-i*(rot/2)*Z)
+                    rot = 2 * params[0] * t
+                    circ.rz(q, rot)
             else:
                 (q0, q1) = link[line - n]
                 theta = 2 * params[0] * t
                 if ins == 0:
                     # R_XX(theta)
                     if abs(theta) > 1e-5:
-                        if (theta / (2 * np.pi)) % 1 <= 0.25 or (theta / (2 * np.pi)) % 1 >= 0.75:
-                            circ.ms(q0, q1, accum_phase[q0], accum_phase[q1], theta % (2 * np.pi))
-                        elif 0.25 <= (theta / (2 * np.pi)) % 1 <= 0.5:
-                            circ.gpi(q0, accum_phase[q0])
-                            circ.gpi(q1, accum_phase[q1])
-                            circ.ms(
-                                q0,
-                                q1,
-                                (accum_phase[q0] + np.pi) % (2 * np.pi),
-                                accum_phase[q1],
-                                np.pi - (theta % (2 * np.pi)),
-                            )
-                        elif 0.5 <= (theta / (2 * np.pi)) % 1 <= 0.75:
-                            circ.gpi(q0, accum_phase[q0])
-                            circ.gpi(q1, accum_phase[q1])
-                            circ.ms(
-                                q0,
-                                q1,
-                                accum_phase[q0],
-                                accum_phase[q1],
-                                (theta % (2 * np.pi)) - np.pi,
-                            )
-                        else:
-                            raise ValueError(
-                                f"Rotation angle is {theta}, should be between 0 and 2*pi"
-                            )
+                        circ.ms(q0, q1, 0, 0, theta)
                 elif ins == 1:
                     # R_YY(theta)
                     if abs(theta) > 1e-5:
-                        if (theta / (2 * np.pi)) % 1 <= 0.25 or (theta / (2 * np.pi)) % 1 >= 0.75:
-                            circ.ms(
-                                q0,
-                                q1,
-                                (accum_phase[q0] + np.pi / 2) % (2 * np.pi),
-                                (accum_phase[q1] + np.pi / 2) % (2 * np.pi),
-                                theta % (2 * np.pi),
-                            )
-                        elif 0.25 <= (theta / (2 * np.pi)) % 1 <= 0.5:
-                            circ.gpi(q0, accum_phase[q0])
-                            circ.gpi(q1, accum_phase[q1])
-                            circ.ms(
-                                q0,
-                                q1,
-                                (accum_phase[q0] + np.pi / 2) % (2 * np.pi),
-                                (accum_phase[q1] + np.pi / 2) % (2 * np.pi),
-                                np.pi - (theta % (2 * np.pi)),
-                            )
-                        elif 0.5 <= (theta / (2 * np.pi)) % 1 <= 0.75:
-                            circ.gpi(q0, accum_phase[q0])
-                            circ.gpi(q1, accum_phase[q1])
-                            circ.ms(
-                                q0,
-                                q1,
-                                (accum_phase[q0] + np.pi / 2) % (2 * np.pi),
-                                (accum_phase[q1] + np.pi / 2) % (2 * np.pi),
-                                (theta % (2 * np.pi)) - np.pi,
-                            )
-                        else:
-                            raise ValueError(
-                                f"Rotation angle is {theta}, should be between 0 and 2*pi"
-                            )
+                        circ.ms(q0, q1, np.pi / 2, np.pi / 2, theta)
                 else:
                     # R_ZZ(theta)
                     if abs(theta) > 1e-5:
                         # R_X(-pi/2)
-                        circ.gpi2(q0, (accum_phase[q0] + np.pi) % (2 * np.pi))
-                        circ.gpi2(q1, (accum_phase[q1] + np.pi) % (2 * np.pi))
+                        circ.gpi2(q0, np.pi)
+                        circ.gpi2(q1, np.pi)
                         # R_YY(theta)
-                        if (theta / (2 * np.pi)) % 1 <= 0.25 or (theta / (2 * np.pi)) % 1 >= 0.75:
-                            circ.ms(
-                                q0,
-                                q1,
-                                (accum_phase[q0] + np.pi / 2) % (2 * np.pi),
-                                (accum_phase[q1] + np.pi / 2) % (2 * np.pi),
-                                theta % (2 * np.pi),
-                            )
-                        elif 0.25 <= (theta / (2 * np.pi)) % 1 <= 0.5:
-                            circ.gpi(q0, accum_phase[q0])
-                            circ.gpi(q1, accum_phase[q1])
-                            circ.ms(
-                                q0,
-                                q1,
-                                (accum_phase[q0] + np.pi / 2) % (2 * np.pi),
-                                (accum_phase[q1] + np.pi / 2) % (2 * np.pi),
-                                np.pi - (theta % (2 * np.pi)),
-                            )
-                        elif 0.5 <= (theta / (2 * np.pi)) % 1 <= 0.75:
-                            circ.gpi(q0, accum_phase[q0])
-                            circ.gpi(q1, accum_phase[q1])
-                            circ.ms(
-                                q0,
-                                q1,
-                                (accum_phase[q0] + np.pi / 2) % (2 * np.pi),
-                                (accum_phase[q1] + np.pi / 2) % (2 * np.pi),
-                                (theta % (2 * np.pi)) - np.pi,
-                            )
-                        else:
-                            raise ValueError(
-                                f"Rotation angle is {theta}, should be between 0 and 2*pi"
-                            )
+                        circ.ms(q0, q1, np.pi / 2, np.pi / 2, theta)
                         # R_X(pi/2)
-                        circ.gpi2(q0, (accum_phase[q0]) % (2 * np.pi))
-                        circ.gpi2(q1, (accum_phase[q1]) % (2 * np.pi))
-    # circ = Circuit().add_verbatim_box(circ)
-    return circ.job, accum_phase
+                        circ.gpi2(q0, 0)
+                        circ.gpi2(q1, 0)
+    return circ
 
 
 def transpile(n, sol_gvars, boxes, edges, backend="simulator", noise_model=None):
     if isinstance(n, list):
         n = len(n)
-    circ, accum_phase = clean_as(n, boxes, edges, backend, noise_model)
-    return circ
+    circ = clean_as(n, boxes, edges, backend, noise_model)
+    return circ.job

--- a/simuq/backends/ionq.py
+++ b/simuq/backends/ionq.py
@@ -2,6 +2,7 @@ import networkx as nx
 import numpy as np
 from ionq_circuit import Circuit
 
+
 def clean_as(n, boxes, edges, backend="simulator", noise_model=None):
     link = [(i, j) for i in range(n) for j in range(i + 1, n)]
     DG = nx.DiGraph()
@@ -9,7 +10,7 @@ def clean_as(n, boxes, edges, backend="simulator", noise_model=None):
     DG.add_edges_from(edges)
     topo_order = list(nx.topological_sort(DG))
     circ = Circuit("test", n, backend, noise_model)
-    
+
     for i in range(len(boxes)):
         idx = topo_order[i]
         t = boxes[idx][1]
@@ -22,7 +23,7 @@ def clean_as(n, boxes, edges, backend="simulator", noise_model=None):
                     phi = params[1]
                     if abs(rot) > 1e-5:
                         circ.rz(q, phi)
-                        
+
                         # Rx(q, rot)
                         turns = rot / (2 * np.pi)
                         if abs(turns - 0.25) < 1e-6:
@@ -35,7 +36,7 @@ def clean_as(n, boxes, edges, backend="simulator", noise_model=None):
                             circ.gpi2(q, 3 * np.pi / 2)
                             circ.rz(q, rot)
                             circ.gpi2(q, np.pi / 2)
-                        
+
                         circ.rz(q, -phi)
 
                 else:
@@ -65,7 +66,7 @@ def clean_as(n, boxes, edges, backend="simulator", noise_model=None):
                         # R_X(pi/2)
                         circ.gpi2(q0, 0)
                         circ.gpi2(q1, 0)
-    return circ
+    return circ.optimize()
 
 
 def transpile(n, sol_gvars, boxes, edges, backend="simulator", noise_model=None):

--- a/simuq/backends/ionq_circuit.py
+++ b/simuq/backends/ionq_circuit.py
@@ -1,11 +1,13 @@
 import numpy as np
 
 
-def to_turns(phi) :
+def to_turns(phi):
     return (phi / (2 * np.pi)) % 1.0
 
-def is_close(a, b, tol = 1e-6) :
+
+def is_close(a, b, tol=1e-6):
     return abs(a - b) < tol
+
 
 class Circuit:
     def __init__(self, name, n_qubits, backend="simulator", noise_model=None):
@@ -38,8 +40,8 @@ class Circuit:
         gate["gate"] = "gpi"
         gate["target"] = q
         gate["phase"] = to_turns(phi + self.accum_phase[q])
-        
-    def rz(self, q, phi) :
+
+    def rz(self, q, phi):
         self.accum_phase[q] -= phi
 
     def ms(self, q0, q1, phi0, phi1, theta):
@@ -49,7 +51,10 @@ class Circuit:
             gate = self.job["body"]["circuit"][-1]
             gate["gate"] = "ms"
             gate["targets"] = [q0, q1]
-            gate["phases"] = [to_turns(phi0 + self.accum_phase[q0]), to_turns(phi1 + self.accum_phase[q1])]
+            gate["phases"] = [
+                to_turns(phi0 + self.accum_phase[q0]),
+                to_turns(phi1 + self.accum_phase[q1]),
+            ]
             gate["angle"] = to_turns(theta / (2 * np.pi))
         elif np.pi / 2 < theta <= np.pi:
             self.gpi(q0, phi0)
@@ -64,7 +69,10 @@ class Circuit:
             gate = self.job["body"]["circuit"][-1]
             gate["gate"] = "ms"
             gate["targets"] = [q0, q1]
-            gate["phases"] = [to_turns(phi0 + self.accum_phase[q0]), to_turns(phi1 + np.pi + self.accum_phase[q1])]
+            gate["phases"] = [
+                to_turns(phi0 + self.accum_phase[q0]),
+                to_turns(phi1 + np.pi + self.accum_phase[q1]),
+            ]
             gate["angle"] = to_turns(2 * np.pi - theta)
 
     @staticmethod
@@ -78,36 +86,55 @@ class Circuit:
         return np.array([[1, -1j * np.exp(-1j * phi)], [-1j * np.exp(1j * phi), 1]]) / np.sqrt(2)
 
     @staticmethod
-    def decomp_rz(U) :
-        if is_close(abs(U[0, 0]), 1) and is_close(abs(U[1, 1]), 1) and is_close(U[1, 0], 0) and is_close(U[0, 1], 0):
+    def decomp_rz(U):
+        if (
+            is_close(abs(U[0, 0]), 1)
+            and is_close(abs(U[1, 1]), 1)
+            and is_close(U[1, 0], 0)
+            and is_close(U[0, 1], 0)
+        ):
             return np.angle(U[1, 1] / U[0, 0])
         return None
 
     @staticmethod
     # _GPi(theta)_Rz(phi*2)_ = GPi(theta + phi)
-    def decomp_gpirz(U) :
-        if is_close(U[0, 0], 0) and is_close(U[1, 1], 0) and is_close(U[0, 1], np.conjugate(U[1, 0])):
+    def decomp_gpirz(U):
+        if (
+            is_close(U[0, 0], 0)
+            and is_close(U[1, 1], 0)
+            and is_close(U[0, 1], np.conjugate(U[1, 0]))
+        ):
             return np.angle(U[1, 0]), 0
         return None
-    
+
     @staticmethod
-    def decomp_gpi2rz(U) :
+    def decomp_gpi2rz(U):
         invsqrt2 = 1 / np.sqrt(2)
-        for i in range(2) :
-            for j in range(2) :
-                if not is_close(abs(U[0, 0]), invsqrt2) :
+        for i in range(2):
+            for j in range(2):
+                if not is_close(abs(U[0, 0]), invsqrt2):
                     return None
         lamb = np.angle(U[1, 1] / U[0, 0])
         ph = lamb / 2
         U *= np.exp(1j * (ph - np.angle(U[1, 1])))
-        if is_close(U[0, 0], invsqrt2) and is_close(U[1, 1], invsqrt2) and is_close(U[0, 1] / -1j, np.conjugate(U[1, 0] / -1j)):
-            return np.angle(U[1, 0] / -1j) - ph, lamb
+        e_iph = np.exp(1j * ph)
+        U[0, :] *= e_iph
+        U[1, :] *= e_iph.conj()
+        if (
+            is_close(U[0, 0], invsqrt2)
+            and is_close(U[1, 1], invsqrt2)
+            and is_close(U[0, 1] / -1j, np.conjugate(U[1, 0] / -1j))
+        ):
+            return np.angle(U[1, 0] / -1j), lamb
         return None
 
     @staticmethod
     # _GPi(theta)_GPi2(-psi+theta)_ = _GPi2(psi+theta)_GPi(theta)_
     # _GPi2(psi+theta)_GPi(theta)_Rz(phi*2)_ = _GPi2(psi+theta)_GPi(theta+phi)_
-    def decomp_gpi2gpirz(U) :
+    # Notice _GPi2(psi+phi)_GPi(phi)_ = _GPi2(phi-psi)_Rz(-psi*2)_  # coefficients may be wrong
+    # The following two can be passed, absorbed by gpi2rz
+    def decomp_gpi2gpirz(U):
+        """
         invsqrt2 = 1 / np.sqrt(2)
         for i in range(2) :
             for j in range(2) :
@@ -118,86 +145,89 @@ class Circuit:
         if is_close(U[0, 0] / -1j, np.conjugate(U[1, 1] / -1j)):
             psi = np.angle(U[0, 0] / U[1, 1]) / 2
             return psi + phi, phi, 0
+        """
+        return None
+
+    def decomp_gpigpi2rz(U):
         return None
 
     @staticmethod
     # _GPi2(psi)_GPi2(phi)_Rz(lamb)_
-    def decomp_gpi2gpi2rz(U) :
-        if is_close(abs(U[0, 0]), 0) :
+    def decomp_gpi2gpi2rz(U):
+        if is_close(abs(U[0, 0]), 0):
             # In this case, the decomp has psi=phi, absorbed by GPi(theta)
             return None
         d = np.angle(U[1, 1] / U[0, 0]) / 2
         U *= np.exp(1j * (d - np.angle(U[1, 1])))
-        if not (is_close(U[0, 0], np.conjugate(U[1, 1])) and is_close(U[0, 1] / -1j, np.conjugate(U[1, 0] / -1j))):
+        if not (
+            is_close(U[0, 0], np.conjugate(U[1, 1]))
+            and is_close(U[0, 1] / -1j, np.conjugate(U[1, 0] / -1j))
+        ):
             return None
-        delta = np.arccos((2 - abs(U[0, 0]) ** 2) / 2)
+        delta = np.arccos((2 - abs(U[0, 0] * 2) ** 2) / 2)
         ph = np.angle(U[1, 1] / (1 - np.exp(-1j * delta)))
         lamb = ph * 2
         mid = np.angle(U[1, 0] / -1j / np.exp(1j * ph))
         psi = mid + delta / 2
         phi = mid - delta / 2
-        if not (is_close(U[1, 0], -1j * np.exp(1j * ph) * (np.exp(1j * psi) + np.exp(1j * phi)))):
+        if not (
+            is_close(U[1, 0], -1j * np.exp(1j * ph) * (np.exp(1j * psi) + np.exp(1j * phi)) / 2)
+        ):
             return None
         return psi, phi, lamb
+
     @staticmethod
-    def decomp_gpi2gpigpi2(U) :
-        if is_close(abs(U[0, 0]), 0) :
+    def decomp_gpi2gpigpi2(U):
+        if is_close(abs(U[0, 0]), 0):
             # In this case, the decomp has psi=phi, absorbed by GPi(theta)
             return None
-        U=U/(U[0][0]/abs(U[0][0]))
-        alpha=np.arccos(U[0][0].real)
-        beta=-np.angle(U[1][1])
-        gamma=np.angle(U[1][0])+beta/2
+        U = U / (U[0][0] / abs(U[0][0]))
+        alpha = np.arccos(U[0][0].real)
+        beta = -np.angle(U[1][1])
+        gamma = np.angle(U[1][0]) + beta / 2
 
-        theta1=(beta+2*gamma)/2
-        theta3=(2*gamma-beta)/2
-        theta2=gamma-alpha
-        return theta1,theta2,theta3
+        theta1 = (beta + 2 * gamma) / 2
+        theta3 = (2 * gamma - beta) / 2
+        theta2 = gamma - alpha
+        return theta1, theta2, theta3
         # GPi2(theta1)@GPi(theta2)@GPi2(theta3)
-    
-    @staticmethod
-    def decomp_unitary(self,q, U, circ) :
-        res = self.decomp_rz(U)
-        if res != None :
-            theta = res
-            circ.rz(q, theta)
-            return
-        res = self.decomp_gpirz(U)
-        if res != None :
-            theta, lamb = res
-            circ.gpi(q, theta)
-            circ.rz(q, lamb)
-            return
-        res = self.decomp_gpi2rz(U)
-        if res != None :
-            theta, lamb = res
-            circ.gpi2(q, theta)
-            circ.rz(q, lamb)
-            return
-        res = self.decomp_gpi2gpirz(U)
-        if res != None :
-            x, y, z = res
-            circ.gpi2(q, x)
-            circ.gpi(q, y)
-            circ.rz(q, z)
-            return
-        res = self.decomp_gpi2gpi2rz(U)
-        if res != None :
-            psi, phi, lamb = res
-            circ.gpi2(q, psi)
-            circ.gpi2(q, phi)
-            circ.rz(q, lamb)
-            return
-        res = self.decomp_gpi2gpigpi2(U)
-        if res != None :
-            theta1,theta2,theta3=res
-            circ.gpi2(q,theta1)
-            circ.gpi(q,theta2)
-            circ.gpi2(q,theta3)
-            return
 
-    def optimize(self) :
-        if "noise" in self.job: 
+    def add_unitary(self, q, U):
+        res = self.decomp_rz(U.copy())
+        if res != None:
+            theta = res
+            self.rz(q, theta)
+            return
+        res = self.decomp_gpirz(U.copy())
+        if res != None:
+            theta, lamb = res
+            self.gpi(q, theta)
+            self.rz(q, lamb)
+            return
+        res = self.decomp_gpi2rz(U.copy())
+        if res != None:
+            theta, lamb = res
+            self.gpi2(q, theta)
+            self.rz(q, lamb)
+            return
+        res = self.decomp_gpi2gpi2rz(U.copy())
+        if res != None:
+            psi, phi, lamb = res
+            self.gpi2(q, psi)
+            self.gpi2(q, phi)
+            self.rz(q, lamb)
+            return
+        res = self.decomp_gpi2gpigpi2(U.copy())
+        if res != None:
+            theta1, theta2, theta3 = res
+            self.gpi2(q, theta1)
+            self.gpi(q, theta2)
+            self.gpi2(q, theta3)
+            return
+        raise Exception("Decomposition failed.")
+
+    def optimize(self):
+        if "noise" in self.job:
             new_circ = Circuit(
                 self.job["name"],
                 self.job["body"]["qubits"],
@@ -210,7 +240,7 @@ class Circuit:
                 self.job["body"]["qubits"],
                 self.job["target"],
             )
-        
+
         identity = np.array([[1, 0], [0, 1]])
         n = self.job["body"]["qubits"]
 
@@ -228,60 +258,67 @@ class Circuit:
                     unitaries[gate["target"]],
                 )
             elif gate["gate"] == "ms":
-                for q in gate["targets"] :
-                    self.decomp_unitary(self,q, unitaries[q], new_circ)
+                for q in gate["targets"]:
+                    new_circ.add_unitary(q, unitaries[q])
+                    unitaries[q] = identity.copy()
                 q0, q1 = gate["targets"]
                 phi0, phi1 = gate["phases"]
                 phi0 *= 2 * np.pi
                 phi1 *= 2 * np.pi
                 angle = gate["angle"] * 2 * np.pi
                 new_circ.ms(q0, q1, phi0, phi1, angle)
-            else :
+            else:
                 raise Exception("Unknown gate:", gate["gate"])
-        for q in range(n) :
-            self.decomp_unitary(self,q, unitaries[q], new_circ)
+
+        for q in range(n):
+            self.add_unitary(self, q, unitaries[q], new_circ)
             new_circ.accum_phase[q] += self.accum_phase[q]
 
         return new_circ
 
-    def to_matrix(self) :
+
+"""
+    def to_matrix(self):
         from qiskit import QuantumCircuit
         from qiskit.quantum_info import Operator
-        circ=QuantumCircuit(self.job["body"]["qubits"])
-        
+
+        circ = QuantumCircuit(self.job["body"]["qubits"])
+
+        from qiskit.circuit.library import RZGate
         from qiskit_ionq import GPI2Gate, GPIGate, IonQProvider, MSGate
 
         for ind, gate in enumerate(self.job["body"]["circuit"]):
             if gate["gate"] == "gpi":
-                circ.append(GPIGate(gate["phase"]),[gate["target"]])
+                circ.append(GPIGate(gate["phase"]), [gate["target"]])
             elif gate["gate"] == "gpi2":
-                circ.append(GPI2Gate(gate["phase"]),[gate["target"]])
-            else :
+                circ.append(GPI2Gate(gate["phase"]), [gate["target"]])
+            else:
                 raise Exception("Unknown gate:", gate["gate"])
+        for q in range(self.job["body"]["qubits"]):
+            circ.append(RZGate(-self.accum_phase[q]), [q])
 
         return Operator(circ).data
+
 def test():
-    circ=Circuit("test", 1, backend="simulator", noise_model=None)
-    from numpy.random import default_rng
-    rng = default_rng()
-    for _ in range(100) :
-        theta1=rng.uniform(0,2*np.pi)
-        theta2=rng.uniform(0,2*np.pi)
-        theta3=rng.uniform(0,2*np.pi)
-        circ.gpi2(0,theta1)
-        circ.gpi(0,theta2)
-        circ.gpi2(0,theta3)
-        new_circ=circ.optimize()
-        mat1=circ.to_matrix()
-        mat1=mat1/(mat1[0][0]/abs(mat1[0][0]))
-        mat2=new_circ.to_matrix()
-        mat2=mat2/(mat2[0][0]/abs(mat2[0][0]))
-        if not is_close(np.linalg.norm(mat1-mat2),0):
+    from scipy.stats import unitary_group
+
+    for _ in range(100):
+        U = unitary_group.rvs(2)
+        circ = Circuit("test", 1)
+        circ.add_unitary(0, U)
+        Uc = circ.to_matrix()
+        Udag_Uc = np.matmul(U.conj().transpose(), Uc)
+        Utar = np.array([[1, 0], [0, 1]]) * Udag_Uc[0, 0]
+        if not is_close(np.linalg.norm(Udag_Uc - Utar), 0):
             print("Test failed")
-            print(new_circ.to_matrix())
-            print(circ.to_matrix())
+            print(U)
+            print(Uc)
+            print(Udag_Uc)
             return
-        
+
     print("Test passed")
+
+
 if __name__ == "__main__":
     test()
+"""

--- a/simuq/backends/ionq_circuit.py
+++ b/simuq/backends/ionq_circuit.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def to_turns(phi) :
     return (phi / (2 * np.pi)) % 1
 
@@ -139,6 +140,21 @@ class Circuit:
             return None
         return psi, phi, lamb
 
+    def decomp_gpi2gpigpi2(U) :
+        if is_close(abs(U[0, 0]), 0) :
+            # In this case, the decomp has psi=phi, absorbed by GPi(theta)
+            return None
+        U=U/(U[0][0]/abs(U[0][0]))
+        alpha=np.arccos(U[0][0])
+        beta=np.angle(U[1][1])
+        gamma=np.angle(U[1][0])-beta/2
+
+        theta1=(beta+2*gamma)/2
+        theta3=(2*gamma-beta)/2
+        theta2=gamma-alpha
+        return theta1,theta2,theta3
+        # GPi2(theta1)@GPi(theta2)@GPi2(theta3)
+    
     @staticmethod
     def decomp_unitary(q, U, circ) :
         res = decomp_rz(U)

--- a/simuq/backends/ionq_circuit.py
+++ b/simuq/backends/ionq_circuit.py
@@ -1,0 +1,215 @@
+import numpy as np
+
+def to_turns(phi) :
+    return (phi / (2 * np.pi)) % 1
+
+def is_close(a, b, tol = 1e-6) :
+    return abs(a - b) < tol
+
+class Circuit:
+    def __init__(self, name, n_qubits, backend="simulator", noise_model=None):
+        self.job = {
+            "lang": "json",
+            "shots": 4096,
+            "name": name,
+            "target": "simulator",
+            "body": {
+                "gateset": "native",
+                "qubits": n_qubits,
+                "circuit": [],
+            },
+        }
+        self.job["target"] = backend
+        if noise_model is not None:
+            self.job["noise"] = {"model": noise_model}
+        self.accum_phase = [0 for _ in range(n_qubits)]
+
+    def gpi2(self, q, phi):
+        self.job["body"]["circuit"].append({})
+        gate = self.job["body"]["circuit"][-1]
+        gate["gate"] = "gpi2"
+        gate["target"] = q
+        gate["phase"] = to_turns(phi + self.accum_phase[q])
+
+    def gpi(self, q, phi):
+        self.job["body"]["circuit"].append({})
+        gate = self.job["body"]["circuit"][-1]
+        gate["gate"] = "gpi"
+        gate["target"] = q
+        gate["phase"] = to_turns(phi + self.accum_phase[q])
+        
+    def rz(self, q, phi) :
+        self.accum_phase[q] -= phi
+
+    def ms(self, q0, q1, phi0, phi1, theta):
+        theta = theta % (2 * np.pi)
+        if 0 <= theta <= np.pi / 2:
+            self.job["body"]["circuit"].append({})
+            gate = self.job["body"]["circuit"][-1]
+            gate["gate"] = "ms"
+            gate["targets"] = [q0, q1]
+            gate["phases"] = [to_turns(phi0 + self.accum_phase[q0]), to_turns(phi1 + self.accum_phase[q1])]
+            gate["angle"] = to_turns(theta / (2 * np.pi))
+        elif np.pi / 2 < theta <= np.pi:
+            self.gpi(q0, phi0)
+            self.gpi(q1, phi1)
+            self.ms(q0, q1, phi0 + np.pi, phi1, np.pi - theta)
+        elif np.pi < theta <= 3 * np.pi / 2:
+            self.gpi(q0, phi0)
+            self.gpi(q1, phi1)
+            self.ms(q0, q1, phi0, phi1, theta - np.pi)
+        elif 3 * np.pi / 2 <= theta <= 2 * np.pi:
+            self.job["body"]["circuit"].append({})
+            gate = self.job["body"]["circuit"][-1]
+            gate["gate"] = "ms"
+            gate["targets"] = [q0, q1]
+            gate["phases"] = [to_turns(phi0 + self.accum_phase[q0]), to_turns(phi1 + np.pi + self.accum_phase[q1])]
+            gate["angle"] = to_turns(2 * pi - theta)
+
+    @staticmethod
+    def gpi_mat(turns):
+        phi = turns * 2 * np.pi
+        return np.array([[0, np.exp(-1j * phi)], [np.exp(1j * phi), 0]])
+
+    @staticmethod
+    def gpi2_mat(turns):
+        phi = turns * 2 * np.pi
+        return np.array([[1, -1j * np.exp(-1j * phi)], [-1j * np.exp(1j * phi), 1]]) / np.sqrt(2)
+
+    @staticmethod
+    def decomp_rz(U) :
+        if is_close(abs(U[0, 0]), 1) and is_close(abs(U[1, 1]), 1) and is_close(U[1, 0], 0) and is_close(U[0, 1], 0):
+            return np.angle(U[1, 1] / U[0, 0])
+        return None
+
+    @staticmethod
+    # _GPi(theta)_Rz(phi*2)_ = GPi(theta + phi)
+    def decomp_gpirz(U) :
+        if is_close(U[0, 0], 0) and is_close(U[1, 1], 0) and is_close(U[0, 1], np.conjugate(U[1, 0])):
+            return np.angle(U[1, 0]), 0
+        return None
+    
+    @staticmethod
+    def decomp_gpi2rz(U) :
+        invsqrt2 = 1 / np.sqrt(2)
+        for i in range(2) :
+            for j in range(2) :
+                if not is_close(abs(U[0, 0]), invsqrt2) :
+                    return None
+        lamb = np.angle(U[1, 1] / U[0, 0])
+        ph = lamb / 2
+        U *= np.exp(1j * (ph - np.angle(U[1, 1])))
+        if is_close(U[0, 0], invsqrt2) and is_close(U[1, 1], invsqrt2) and is_close(U[0, 1] / -1j, np.conjugate(U[1, 0] / -1j)):
+            return np.angle(U[1, 0] / -1j) - ph, lamb
+        return None
+
+    @staticmethod
+    # _GPi(theta)_GPi2(-psi+theta)_ = _GPi2(psi+theta)_GPi(theta)_
+    # _GPi2(psi+theta)_GPi(theta)_Rz(phi*2)_ = _GPi2(psi+theta)_GPi(theta+phi)_
+    def decomp_gpi2gpirz(U) :
+        invsqrt2 = 1 / np.sqrt(2)
+        for i in range(2) :
+            for j in range(2) :
+                if not is_close(abs(U[0, 0]), invsqrt2) :
+                    return None
+        phi = np.angle(U[1, 0] / U[0, 1]) / 2
+        U *= np.exp(1j * (phi - np.angle(U[1, 0])))
+        if is_close(U[0, 0] / -1j, np.conjugate(U[1, 1] / -1j)):
+            psi = np.angle(U[0, 0] / U[1, 1]) / 2
+            return psi + phi, phi, 0
+        return None
+
+    @staticmethod
+    # _GPi2(psi)_GPi2(phi)_Rz(lamb)_
+    def decomp_gpi2gpi2rz(U) :
+        if is_close(abs(U[0, 0]), 0) :
+            # In this case, the decomp has psi=phi, absorbed by GPi(theta)
+            return None
+        d = np.angle(U[1, 1] / U[0, 0]) / 2
+        U *= np.exp(1j * (d - np.angle(U[1, 1])))
+        if not (is_close(U[0, 0], np.conjugate(U[1, 1])) and is_close(U[0, 1] / -1j, np.conjugate(U[1, 0] / -1j))):
+            return None
+        delta = np.arccos((2 - abs(U[0, 0]) ** 2) / 2)
+        ph = np.angle(U[1, 1] / (1 - np.exp(-1j * delta)))
+        lamb = ph * 2
+        mid = np.angle(U[1, 0] / -1j / np.exp(1j * ph))
+        psi = mid + delta / 2
+        phi = mid - delta / 2
+        if not (is_close(U[1, 0], -1j * np.exp(1j * ph) * (np.exp(1j * psi) + np.exp(1j * phi)))):
+            return None
+        return psi, phi, lamb
+
+    @staticmethod
+    def decomp_unitary(q, U, circ) :
+        res = decomp_rz(U)
+        if res != None :
+            theta = res
+            circ.rz(q, theta)
+            return
+        res = decomp_gpirz(U)
+        if res != None :
+            theta, lamb = res
+            circ.gpi(q, theta)
+            circ.rz(q, lamb)
+            return
+        res = decomp_gpi2rz(U)
+        if res != None :
+            theta, lamb = res
+            circ.gpi2(q, theta)
+            circ.rz(q, lamb)
+            return
+        res = decomp_gpi2gpirz(U)
+        if res != None :
+            x, y, z = res
+            circ.gpi2(q, x)
+            circ.gpi(q, y)
+            circ.rz(q, z)
+            return
+        res = decomp_gpi2gpi2rz(U)
+        if res != None :
+            psi, phi, lamb = res
+            circ.gpi2(q, psi)
+            circ.gpi2(q, phi)
+            circ.rz(q, lamb)
+            return
+
+    def optimize(self) :
+        new_circ = Circuit(
+            self.job["name"],
+            self.job["body"]["qubits"],
+            self.job["target"],
+            self.job["noise"]["model"],
+        )
+        
+        identity = np.arrays([[1, 0], [0, 1]])
+        n = self.job["body"]["qubits"]
+
+        unitaries = [identity.copy() for _ in range(n)]
+
+        for ind, gate in enumerate(self.job["body"]["circuit"]):
+            if gate["gate"] == "gpi":
+                unitaries[gate["target"]] = np.matmul(
+                    self.gpi_mat(gate["angle"]),
+                    unitaries[gate["target"]],
+                )
+            elif gate["gate"] == "gpi2":
+                unitaries[gate["target"]] = np.matmul(
+                    self.gpi2_mat(gate["angle"]),
+                    unitaries[gate["target"]],
+                )
+            elif gate["gate"] == "ms":
+                for q in gate["targets"] :
+                    self.decomp_unitary(q, unitaries[q], new_circ)
+                q0, q1 = gate["targets"]
+                phi0, phi1 = gate["phases"]
+                phi0 *= 2 * np.pi
+                phi1 *= 2 * np.pi
+                angle = gate["angle"] * 2 * np.pi
+                new_circ.ms(q0, q1, phi0, phi1, angle)
+            else :
+                raise Exception("Unknown gate:", gate["gate"])
+        for q in range(n) :
+            self.decomp_unitary(q, unitaries[q], new_circ)
+            new_circ.accum_phase[q] += self.accum_phase[q]
+
+        return new_circ

--- a/simuq/backends/ionq_circuit.py
+++ b/simuq/backends/ionq_circuit.py
@@ -188,6 +188,13 @@ class Circuit:
             circ.gpi2(q, phi)
             circ.rz(q, lamb)
             return
+        res = decomp_gpi2gpigpi2(U)
+        if res != None :
+            theta1,theta2,theta3=res
+            circ.gpi2(q,theta1)
+            circ.gpi(q,theta2)
+            circ.gpi2(q,theta3)
+            return
 
     def optimize(self) :
         new_circ = Circuit(


### PR DESCRIPTION
I have detached the `Circuit` class from the IonQ transpiler (only `ionq.py` has instantiated this change now). 
Also, I added an optimizer for the Circuit class, where 1-q gates between 2 MS gates are reconstructed by at most 3 GPi/GPi2 gates. 