### PR TITLE
Bug fixes for IonQ in Braket provider

### DIFF
--- a/src/simuq/braket/braket_provider.py
+++ b/src/simuq/braket/braket_provider.py
@@ -169,7 +169,16 @@ class BraketProvider(BaseProvider):
         elif self.provider == "ionq":
             if on_simulator:
                 simulator = LocalSimulator()
-                self.task = simulator.run(self.prog, shots=shots)
+
+                # Insert identity when a qubit is not targeted by any gates
+                prog = self.prog.copy()
+                used_qubits = {qubit for inst in prog.instructions for qubit in inst.target}
+                max_qubit = max(used_qubits)
+                for index in range(max_qubit):
+                    if index not in used_qubits:
+                        prog.i(index)
+
+                self.task = simulator.run(prog, shots=shots)
                 if verbose >= 0:
                     print("Submitted.")
             else:


### PR DESCRIPTION
Fixes a few bugs for IonQ in the Braket provider:

1) Braket uses raw angles, not turn count.
2) Typo in ms gate in the BraketIonQCircuit implementation.
3) The Braket local simulator doesn't accept noncontiguous qubit indices, which can happen if the input circuits only have RZ gates (they're compiled out). For the local simulator we add identities on those qubits for now.