### PR TITLE
Remove qiskit-terra explicit dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         "qiskit": [
             "matplotlib",
             "qiskit",
-            "qiskit-terra",
             "qiskit-ibmq-provider",
         ],
         "qutip": [


### PR DESCRIPTION
`qiskit-terra` is part of the `qiskit<1` meta-package. Keeping the double-dependency is redundant and forces to keep them in track. Additionally `qiskit-terra` is on its way to sunset.