### PR TITLE
fix avg_qpu_time calculation

### DIFF
--- a/src/simuq/dwave/dwave_provider.py
+++ b/src/simuq/dwave/dwave_provider.py
@@ -65,7 +65,7 @@ class DWaveProvider(BaseProvider):
                                         )
         self.samples = list(response.samples())
         self.time_on_machine = response.info['timing']['qpu_access_time'] * 1e-6
-        self.avg_qpu_time = response.info['timing']['qpu_access_time'] * 10e-6 / self.shots
+        self.avg_qpu_time = response.info['timing']['qpu_access_time'] * 1e-6 / self.shots
         self.num_occurrences = list(response.data_vectors['num_occurrences'])
         return response
 


### PR DESCRIPTION
The `avg_qpu_time`, given in microseconds in the D-Wave response object, seems to be multiplied by 10e-6 instead of 1e-6 when converting to seconds.